### PR TITLE
Revert "Fix detours with RunString, RunStringEx, & CompileString (#56)"

### DIFF
--- a/lua/autorun/server/sv_trinity.lua
+++ b/lua/autorun/server/sv_trinity.lua
@@ -63,6 +63,9 @@ AddCSLuaFile("external/atlas/cl_atlas.lua")
 MsgN("  Creating pLib instance")
 include("external/sv_plib.lua")
 
+MsgN("  Creating fLib instance")
+include("external/sv_flib.lua")
+
 --- Lists ---
  
 MsgN("  Caching lists")

--- a/lua/external/sv_flib.lua
+++ b/lua/external/sv_flib.lua
@@ -1,0 +1,40 @@
+-- Fork of: 
+-- https://github.com/ryanoutcome20/fLib
+
+fLib = { }
+
+function fLib:Start(...)
+	if not TAC.Debug then
+		return
+	end
+
+	if not FProfiler or not FProfiler.start then
+		return
+	end
+	
+	return FProfiler.start(...)
+end
+
+function fLib:Stop(...)
+	if not TAC.Debug then
+		return
+	end
+	
+	if not FProfiler or not FProfiler.stop then
+		return
+	end
+	
+	return FProfiler.stop(...)
+end
+
+function fLib:ContinueProfiling(...)
+	if not TAC.Debug then
+		return
+	end
+	
+	if not FProfiler or not FProfiler.continueProfiling then
+		return
+	end
+	
+	return FProfiler.continueProfiling(...)
+end

--- a/lua/external/sv_plib.lua
+++ b/lua/external/sv_plib.lua
@@ -1,6 +1,3 @@
--- Fork of:
--- https://github.com/ryanoutcome20/pLib
-
 pLib = { 
 	Cores = { }
 }

--- a/lua/tac/client.lua
+++ b/lua/tac/client.lua
@@ -24,6 +24,13 @@ TAC.Print = include("external/sh_print.lua")
 
 TAC.Loaded = 0
 
+--- Plugin Setup ---
+
+TAC.Sizes = {
+	Commands = {Key = concommand.GetTable, Index = 1},
+	Net = {Key = net.Receivers, Index = -1}
+}
+
 --- Localizers ---
 
 TAC.Localizers = { }
@@ -99,20 +106,13 @@ local surface = Get("surface")
 local notify = Get("notify")
 local concommand = Get("concommand")
 
-local tostring = Get("tostring")
-local tobool = Get("tobool")
-local istable = Get("istable")
-local isstring = Get("isstring")
 local pcall = Get("pcall")
-local pairs = Get("pairs")
-local ipairs = Get("ipairs")
 local setfenv = Get("setfenv")
 local getfenv = Get("getfenv")
 local Color = Get("Color")
 local Angle = Get("Angle")
 local Vector = Get("Vector")
 local include = Get("include")
-local CompileString = Get("CompileString")
 local CreateClientConVar = Get("CreateClientConVar")
 local LocalPlayer = Get("LocalPlayer")
 local FindMetaTable = Get("FindMetaTable")
@@ -166,6 +166,22 @@ function TAC.Size(Table)
 	return Size
 end
 
+function TAC.Visible(Mask, Target, From)
+	From = From or LocalPlayer():EyePos()
+	
+	local Trace = util.TraceLine({
+		start = From,
+		endpos = Target:EyePos(),
+		mask = Mask,
+		filter = {
+			LocalPlayer(), 
+			Target
+		}
+	})
+	
+	return not Trace.Hit or Trace.Entity == Target
+end
+
 function TAC.StandardAngle(Yaw)
 	if Yaw >= 0 and Yaw <= 180 then
 		return Yaw
@@ -200,6 +216,108 @@ function TAC.GetBinaryNames(Name)
 	end
 	
 	return Names
+end
+
+--- Batch System ---
+
+TAC.Batch = {
+	Cache = { },
+	Buffer = { },
+	Head = 1
+}
+
+function TAC.Batch.Add(Message, Data, Size)
+	TAC.Batch.Buffer[#TAC.Batch.Buffer + 1] = {
+		Message = Message,
+		Data = Data,
+		Size = Size
+	}
+end
+
+function TAC.Batch.Process()
+	-- Check if we have anything to process.
+	if TAC.Batch.Head > #TAC.Batch.Buffer then
+		TAC.Batch.Head = 1
+		TAC.Batch.Buffer = { }
+		return
+	end
+	
+	-- Get our batch that we're sending.
+	local Objects = {
+		Send = { },
+		Size = 0
+	}
+	
+	while true do 
+		local Object = TAC.Batch.Buffer[TAC.Batch.Head]
+		
+		if not Object then
+			break
+		end
+		
+		if Objects.Size + Object.Size > TAC.Config.Batch then
+			break
+		end
+		
+		Objects.Size = Objects.Size + Object.Size
+		
+		Objects.Send[Object.Message] = Objects.Send[Object.Message] or { }
+		
+		table.insert(Objects.Send[Object.Message], Object.Data)
+		
+		TAC.Batch.Head = TAC.Batch.Head + 1
+	end
+	
+	-- Check if we even have anything to process.
+	if Objects.Size == 0 then
+		return
+	end
+	
+	-- Send our alerts.
+	for Name, Send in pairs(Objects.Send) do 
+		TAC.Atlas:Send(
+			Name .. " Batch",
+			Send
+		)
+	end
+end
+
+timer.Create("Batch", 0.25, 0, TAC.Batch.Process)
+
+--- Flag System ---
+
+function TAC.FlagEx(Buffered, cID, Message, ...)
+	local Data = {
+		cID = cID,
+		Message = string.format(
+			Message,
+			...
+		)
+	}
+
+	if Buffered then
+		TAC.Batch.Add(
+			"Flag", 
+			Data, 
+			#Data.cID + #Data.Message
+		)
+		
+		return
+	end
+	
+	TAC.Atlas:Send(
+		"Flag", 
+		Data
+	)
+end
+
+function TAC.Flag(cID, Message, ...)	
+	return TAC.FlagEx(
+		true,
+		cID,
+		Message,
+		...
+	)
 end
 
 --- List Manager ---
@@ -268,10 +386,10 @@ end
 
 --- Function Buffers ---
 
-function TAC.GenerateBuffer(Function)
+function TAC.GenerateBuffer(Function, noFormat)
 	local GetInfo, FuncInfo = debug.getinfo(Function), jit.util.funcinfo(Function)
 
-	return {
+	local Data = {
 		source = tostring(GetInfo.source or "s"):gsub("\\", "/"), -- OS specific. (#13)
 		short_src = GetInfo.short_src or "sh",
 		what = GetInfo.what or "wh",
@@ -286,6 +404,23 @@ function TAC.GenerateBuffer(Function)
 		
 		equals = (GetInfo.func == Function) and "fde" or "fne"
 	}
+	
+	if noFormat then
+		return Data
+	end
+
+	return string.format(
+		"%s:%s:%s:%s:%s:%s:%s:%s:%s",
+		Data.source,
+		Data.short_src,
+		Data.what,
+		Data.linedefined,
+		Data.lastlinedefined,
+		Data.j_linedefined,
+		Data.j_ffid,
+		Data.j_upvalues,
+		Data.equals
+	)
 end
 
 function TAC.GenerateUpvalueTree(Function)
@@ -293,7 +428,7 @@ function TAC.GenerateUpvalueTree(Function)
 	local Variables = { }
 
 	if Info and Info.what == "Lua" then
-		local Upvalues = Info.nups
+		local Upvalues = info.nups
 
 		for i = 1, Upvalues do
 			local k,v = debug.getupvalue(Function, i)
@@ -304,8 +439,6 @@ function TAC.GenerateUpvalueTree(Function)
 
 	return Variables
 end
-
-_G.GenerateUpvalueTree = TAC.GenerateUpvalueTree
 
 --- Detour System ---
 
@@ -443,111 +576,6 @@ TAC.Localizers.Table.hook.Add = TAC.Hooks.Add
 TAC.Localizers.Table.hook.Remove = TAC.Hooks.Remove
 TAC.Localizers.Table.hook.Run = TAC.Hooks.Run
 
---- Batch System ---
-
-TAC.Batch = {
-	Cache = { },
-	Buffer = { },
-	Head = 1
-}
-
-function TAC.Batch.Add(Message, Data, Size)
-	TAC.Batch.Buffer[#TAC.Batch.Buffer + 1] = {
-		Message = Message,
-		Data = Data,
-		Size = Size
-	}
-end
-
-function TAC.Batch.Process()
-	-- Add our repeat timer.
-	timer.Simple(TAC.Config.ProcessTime, TAC.Batch.Process)
-
-	-- Check if we have anything to process.
-	if TAC.Batch.Head > #TAC.Batch.Buffer then
-		TAC.Batch.Head = 1
-		TAC.Batch.Buffer = { }
-		return
-	end
-	
-	-- Get our batch that we're sending.
-	local Objects = {
-		Send = { },
-		Size = 0
-	}
-	
-	while true do 
-		local Object = TAC.Batch.Buffer[TAC.Batch.Head]
-		
-		if not Object then
-			break
-		end
-		
-		if Objects.Size + Object.Size > TAC.Config.Batch then
-			break
-		end
-		
-		Objects.Size = Objects.Size + Object.Size
-		
-		Objects.Send[Object.Message] = Objects.Send[Object.Message] or { }
-		
-		table.insert(Objects.Send[Object.Message], Object.Data)
-		
-		TAC.Batch.Head = TAC.Batch.Head + 1
-	end
-	
-	-- Check if we even have anything to process.
-	if Objects.Size == 0 then
-		return
-	end
-	
-	-- Send our alerts.
-	for Name, Send in pairs(Objects.Send) do 
-		TAC.Atlas:Send(
-			Name .. " Batch",
-			Send
-		)
-	end
-end
-
-TAC.Hooks.Add("TAC.TransferConfig", "TAC.Batch.Process", TAC.Batch.Process)
-
---- Flag System ---
-
-function TAC.FlagEx(Buffered, cID, Message, ...)
-	local Data = {
-		cID = cID,
-		Message = string.format(
-			Message,
-			...
-		)
-	}
-
-	if Buffered then
-		TAC.Batch.Add(
-			"Flag", 
-			Data, 
-			#Data.cID + #Data.Message
-		)
-		
-		return
-	end
-	
-	TAC.Atlas:Send(
-		"Flag", 
-		Data
-	)
-end
-
-function TAC.Flag(cID, Message, ...)	
-	return TAC.FlagEx(
-		true,
-		cID,
-		Message,
-		...
-	)
-end
-
 --- Config System ---
 
 TAC.Config = { }
@@ -557,6 +585,28 @@ TAC.Atlas:Listen("Config", "TAC.Config", MODE_DONE, function(Stage, Config)
 
 	TAC.Hooks.Run("TAC.TransferConfig", Config)
 end)
+
+--- Build Sizes ---
+
+for k, Object in pairs(TAC.Sizes) do 
+	if Object.Index == -1 then
+		Object.Size = table.Count(Object.Key)
+	else	
+		local Key, Value = debug.getupvalue(Object.Key, Object.Index)
+		
+		if istable(Value) then
+			Object.Size = table.Count(Value)
+		end
+	end
+end
+
+--- Load Message ---
+
+TAC.Print(
+	PRINT_INFO,
+	"Info",
+	"Trinity Pre-Init Loaded"
+)
 
 --- Plugin System ---
 
@@ -698,230 +748,6 @@ TAC.Detour.Register("debug.getupvalue", function(Original, Function, ...)
 	end
 
 	return Name, Value
-end)
-
---- Libraries Check ---
-
-TAC.Libraries = {
-	Slots = {
-		{
-			Key = concommand.GetTable,
-			Config = "concommand", 
-			Index = "CommandList"
-		},
-		{
-			Key = net.Receivers,
-			Config = "net"
-		}
-	}
-}
-
-for k, Data in ipairs(TAC.Libraries.Slots) do 
-	local Size = -1
-
-	if Data.Index then
-		Size = table.Count(TAC.GenerateUpvalueTree(Data.Key)[Data.Index])
-	else
-		Size = table.Count(Data.Key)
-	end
-
-	Data.Size = Size
-end
-
-function TAC.Libraries.Run()
-	local Config = TAC.Config.Libraries
-
-	if not Config.Enabled then
-		return
-	end
-
-	for k, Data in ipairs(TAC.Libraries.Slots) do 
-		local Sub = Config[Data.Config]
-
-		if not Sub.Enabled then
-			continue
-		end
-
-		if not Data.Size or Data.Size ~= Sub.Size then
-			return TAC.Flag("Libraries", "Bad Libraries [%s; expected: %i; got: %s]", Data.Config, Sub.Size, Data.Size)
-		end
-	end
-end
-
-TAC.Hooks.Add("TAC.TransferConfig", "TAC.Libraries.Run", TAC.Libraries.Run)
-
---- Captures ---
-
-TAC.Captures = {
-	Data = { },
-	Ran = { }
-}
-
-function TAC.Captures.Direct(Function, Message)
-	local Data = TAC.GenerateBuffer(Function)
-	
-	if TAC.Detours.Whitelist.Whitelisted(Function, Data) then
-		return
-	end
-
-	Data.Message = Message
-	
-	TAC.Batch.Add(
-		"Function", 
-		Data, 
-		TAC.Size(Data)
-	)
-end
-
-function TAC.Captures.Stack(Message)
-	for i = 3, 8 do 
-		local Info = debug.getinfo(i, "f")
-	
-		if not Info then
-			break
-		end
-		
-		local Hash = tostring(Info.func)
-		
-		if TAC.Captures.Ran[Hash] then
-			continue
-		end
-		
-		TAC.Captures.Direct(Info.func, Message)
-		
-		TAC.Captures.Ran[Hash] = true
-	end
-end
-
---- Detours ---
-
-TAC.Detours = { 
-	Whitelist = {
-		Counter = 0,
-		Identifiers = { 
-			["RunString(Ex)"] = true,
-			["CompileString"] = true
-		},
-		Hashes = { },
-		Dumps = { }
-	}
-}
-
-setmetatable(TAC.Detours.Whitelist.Dumps, {
-	__mode = "k"
-})
-
-function TAC.Detours.Whitelist.Whitelisted(Function, Info)
-	local Whitelist = TAC.Detours.Whitelist
-
-	if Whitelist.Counter == 0 or not Whitelist.Identifiers[Info.short_src] then
-		return false
-	end
-
-	if tobool(Info.isfunc) and Info.what ~= "main" then
-		if Info.namewhat == "global" and not _G[Info.name] then
-			TAC.Audit(
-				"Whitelist encountered secure sub environment, possible bypass attempt?", 
-				"Detours",
-				"Sub Environment"
-			)
-		end
-		
-		return true
-	end
-	
-	local Hash = Whitelist.Hash(Function, Info.short_src)
-
-	if Hash and Whitelist.Hashes[Hash] then
-		Whitelist.Counter = math.max(Whitelist.Counter - 1, 0)
-		return true
-	end
-	
-	return false
-end
-
-function TAC.Detours.Whitelist.Hash(Function, Identifier)
-	if not Function then
-		return
-	end
-	
-	if isstring(Function) then
-		Function = CompileString(Function, Identifier)
-	end
-	
-	if TAC.Detours.Whitelist.Dumps[Function] then
-		return TAC.Detours.Whitelist.Dumps[Function]
-	end
-
-	local Valid, Dump = pcall(string.dump, Function, true)
-
-	if not Valid then
-		return 
-	end
-	
-	local Checksum = util.CRC(Dump) 
-	
-	TAC.Detours.Whitelist.Dumps[Function] = Checksum
-	
-	return Checksum
-end
-
-function TAC.Detours.Whitelist.Increment()
-	TAC.Detours.Whitelist.Counter = TAC.Detours.Whitelist.Counter + 1
-end
-
-function TAC.Detours.Whitelist.Update(Code, Identifier)
-	TAC.Detours.Whitelist.Hashes[TAC.Detours.Whitelist.Hash(Code, Identifier)] = true
-end
-
-TAC.Detour.Register("RunString", function(Original, Code, Identifier, ...)
-	TAC.Captures.Stack("RunString")
-	
-	if Identifier then
-		TAC.Detours.Whitelist.Identifiers[Identifier] = true
-	end
-	
-	if isstring(Code) then
-		TAC.Detours.Whitelist.Update(Code, Identifier)
-	end
-	
-	TAC.Detours.Whitelist.Increment()
-	
-	return Original(Code, Identifier, ...)
-end)
-
-TAC.Detour.Register("RunStringEx", function(Original, Code, Identifier, ...)
-	TAC.Captures.Stack("RunStringEx")
-	
-	if Identifier then
-		TAC.Detours.Whitelist.Identifiers[Identifier] = true
-	end
-	
-	if isstring(Code) then
-		TAC.Detours.Whitelist.Update(Code, Identifier)
-	end
-	
-	TAC.Detours.Whitelist.Increment()
-	
-	return Original(Code, Identifier, ...)
-end)
-
-TAC.Detour.Register("CompileString", function(Original, Code, Identifier, ...)
-	TAC.Captures.Stack("CompileString")
-	
-	if Identifier then
-		TAC.Detours.Whitelist.Identifiers[Identifier] = true
-	end
-	
-	local Output = Original(Code, Identifier, ...)
-
-	if isfunction(Output) then		
-		TAC.Detours.Whitelist.Update(Output, Identifier)
-	end
-	
-	TAC.Detours.Whitelist.Increment()
-	
-	return Output
 end)
 
 --- Debug Mode ---

--- a/lua/tac/config/client.lua
+++ b/lua/tac/config/client.lua
@@ -9,7 +9,6 @@ local Config = { }
 --- Flag Batches ---
 
 Config.Batch = 32000
-Config.ProcessTime = 0.1
 
 --- Aimbot Checks ---
 
@@ -79,15 +78,11 @@ Config.DebugSelf = true
 Config.Libraries = {
 	Enabled = true,
 	
-	concommand = {
-		Enabled = true,
-		Size = 1
-	},
-	
-	net = {
-		Enabled = true,
-		Size = 4
-	}
+	Command = true,
+	Commands = 1,
+			
+	Net = true,
+	Nets = 4
 }
 
 Config.DebugHooks = {

--- a/lua/tac/modules/aimbot/sv_angles.lua
+++ b/lua/tac/modules/aimbot/sv_angles.lua
@@ -6,10 +6,10 @@ function TAC.Aimbot.Angles(Player, cNew, cOld, CUserCMD)
 	end
 
 	local Angles = cNew:GetViewAngles()
-
-	if Config.CheckPitch and math.abs(Angles.x) > (Config.MaxPitch + 1) then
+	
+	if Config.CheckPitch and math.abs(Angles.x) > Config.MaxPitch then
 		TAC.Punishment.Wrapper("Angles", Player, "Angles [x: %i y: %i; bad x]", Angles.x, Angles.y)	
-	elseif Config.CheckYaw and math.abs(Angles.y) > (Config.MaxYaw + 1) then
+	elseif Config.CheckYaw and math.abs(Angles.y) > Config.MaxYaw then
 		TAC.Punishment.Wrapper("Angles", Player, "Angles [x: %i y: %i; bad y]", Angles.x, Angles.y)
 	end
 end

--- a/lua/tac/modules/detours/cl_capture.lua
+++ b/lua/tac/modules/detours/cl_capture.lua
@@ -1,0 +1,44 @@
+TAC.Captures = {
+	Data = { },
+	Ran = { }
+}
+
+local tostring = tostring
+
+local debug_getinfo = debug.getinfo
+
+function TAC.Captures.Direct(Function, Message)
+	TAC.Captures.Data = TAC.GenerateBuffer(Function, true)
+	
+	if TAC.Detours.Whitelist.Whitelisted(Function, TAC.Captures.Data) then
+		return
+	end
+
+	TAC.Captures.Data.Message = Message
+	
+	TAC.Batch.Add(
+		"Function", 
+		TAC.Captures.Data, 
+		TAC.Size(TAC.Captures.Data)
+	)
+end
+
+function TAC.Captures.Stack(Message)
+	for i = 3, 8 do 
+		local Info = debug_getinfo(i, "f")
+	
+		if not Info then
+			break
+		end
+		
+		local Hash = tostring(Info.func)
+		
+		if TAC.Captures.Ran[Hash] then
+			continue
+		end
+		
+		TAC.Captures.Direct(Info.func, Message)
+		
+		TAC.Captures.Ran[Hash] = true
+	end
+end

--- a/lua/tac/modules/detours/cl_detours.lua
+++ b/lua/tac/modules/detours/cl_detours.lua
@@ -10,6 +10,58 @@ local Wrap = function(ID, Meta)
 	end, Meta)
 end
 
+--- Whitelist ---
+
+Detour("RunString", function(Original, Code, Identifier, ...)
+	TAC.Captures.Stack("RunString")
+	
+	if Identifier then
+		TAC.Detours.Whitelist.Identifiers[Identifier] = true
+	end
+	
+	if isstring(Code) then
+		TAC.Detours.Whitelist.Update(Code, Identifier)
+	end
+	
+	TAC.Detours.Whitelist.Increment()
+	
+	return Original(Code, Identifier, ...)
+end)
+
+Detour("RunStringEx", function(Original, Code, Identifier, ...)
+	TAC.Captures.Stack("RunStringEx")
+	
+	if Identifier then
+		TAC.Detours.Whitelist.Identifiers[Identifier] = true
+	end
+	
+	if isstring(Code) then
+		TAC.Detours.Whitelist.Update(Code, Identifier)
+	end
+	
+	TAC.Detours.Whitelist.Increment()
+	
+	return Original(Code, Identifier, ...)
+end)
+
+Detour("CompileString", function(Original, Code, Identifier, ...)
+	TAC.Captures.Stack("CompileString")
+	
+	if Identifier then
+		TAC.Detours.Whitelist.Identifiers[Identifier] = true
+	end
+	
+	local Output = Original(Code, Identifier, ...)
+
+	if isfunction(Output) then		
+		TAC.Detours.Whitelist.Update(Output, Identifier)
+	end
+	
+	TAC.Detours.Whitelist.Increment()
+	
+	return Output
+end)
+
 --- Globals ---
 
 Wrap("gcinfo")
@@ -27,6 +79,7 @@ Wrap("GetConVar_Internal")
 
 --- Classes ---
 
+Wrap("CommandNumber", "CUserCmd")
 Wrap("TickCount", "CUserCmd")
 Wrap("SetViewAngles", "CUserCmd")
 Wrap("SetMouseX", "CUserCmd")

--- a/lua/tac/modules/detours/cl_whitelist.lua
+++ b/lua/tac/modules/detours/cl_whitelist.lua
@@ -1,0 +1,84 @@
+TAC.Detours.Whitelist = {
+	Counter = 0,
+	Identifiers = { 
+		["RunString(Ex)"] = true,
+		["CompileString"] = true
+	},
+	Hashes = { },
+	Dumps = { }
+}
+
+setmetatable(TAC.Detours.Whitelist.Dumps, {
+	__mode = "k"
+})
+
+local tobool = tobool
+local isstring = isstring
+local pcall = pcall
+local CompileString = CompileString
+
+local math_max = math.max
+local util_CRC = util.CRC
+
+function TAC.Detours.Whitelist.Whitelisted(Function, Info)
+	local Whitelist = TAC.Detours.Whitelist
+
+	if Whitelist.Counter == 0 or not Whitelist.Identifiers[Info.short_src] then
+		return false
+	end
+
+	if tobool(Info.isfunc) and Info.what ~= "main" then
+		if Info.namewhat == "global" and not _G[Info.name] then
+			TAC.Audit(
+				"Whitelist encountered secure sub environment, possible bypass attempt?", 
+				"Detours",
+				"Sub Environment"
+			)
+		end
+		
+		return true
+	end
+	
+	local Hash = Whitelist.Hash(Function, Info.short_src)
+
+	if Hash and Whitelist.Hashes[Hash] then
+		Whitelist.Counter = math_max(Whitelist.Counter - 1, 0)
+		return true
+	end
+	
+	return false
+end
+
+function TAC.Detours.Whitelist.Hash(Function, Identifier)
+	if not Function then
+		return
+	end
+	
+	if isstring(Function) then
+		Function = CompileString(Function, Identifier)
+	end
+	
+	if TAC.Detours.Whitelist.Dumps[Function] then
+		return TAC.Detours.Whitelist.Dumps[Function]
+	end
+
+	local Valid, Dump = pcall(string.dump, Function, true)
+
+	if not Valid then
+		return 
+	end
+	
+	local Checksum = util_CRC(Dump) 
+	
+	TAC.Detours.Whitelist.Dumps[Function] = Checksum
+	
+	return Checksum
+end
+
+function TAC.Detours.Whitelist.Increment()
+	TAC.Detours.Whitelist.Counter = TAC.Detours.Whitelist.Counter + 1
+end
+
+function TAC.Detours.Whitelist.Update(Code, Identifier)
+	TAC.Detours.Whitelist.Hashes[TAC.Detours.Whitelist.Hash(Code, Identifier)] = true
+end

--- a/lua/tac/modules/detours/init.lua
+++ b/lua/tac/modules/detours/init.lua
@@ -1,3 +1,8 @@
+if CLIENT then
+	TAC.Detours = {	}
+	return
+end
+
 TAC.Detours = { 
 	Cache = { }
 }
@@ -15,5 +20,8 @@ function TAC.Detours.Wrapper(Player, Message, ...)
 end
 
 return {
+	"init.lua",
+	"cl_capture.lua",
+	"cl_whitelist.lua",
 	"cl_detours.lua"
 }

--- a/lua/tac/modules/exploits/sv_act.lua
+++ b/lua/tac/modules/exploits/sv_act.lua
@@ -1,4 +1,7 @@
 function TAC.Exploits.Act(Player, cNew, cOld, CUserCMD)
+	-- You can technically bypass this in C++ which is why this isn't
+	-- a clientside module.
+	
 	local Config = TAC.Config.Act
 	
 	if not Config.Enabled then

--- a/lua/tac/modules/integrity/cl_jit_hooks.lua
+++ b/lua/tac/modules/integrity/cl_jit_hooks.lua
@@ -1,0 +1,78 @@
+TAC.JITHooks = { }
+
+local Config = TAC.Config.JITHooks
+
+local List = TAC.Lists.Merge("JIT Hooks")
+
+function TAC.JITHooks.Scan(Function, ...)
+    local Lines = 0
+
+    collectgarbage()
+
+    local Pre = collectgarbage("count")
+
+    debug.sethook(function()
+        Lines = Lines + 1
+        
+        for i = 1, Config.Fill do 
+            debug.getinfo(i, "f")
+            continue
+        end
+    end, "l")
+	pcall(Function, ...)
+    debug.sethook()
+
+    local Post = collectgarbage("count")
+
+    return {
+        Lines = Lines,
+        Garbage = Post - Pre
+    }
+end
+
+function TAC.JITHooks.Run(Function)
+    if debug.getinfo(Function, "S").what ~= "C" then 
+        return false
+    end
+
+    jit.flush()
+    collectgarbage()
+
+    local Initial = TAC.JITHooks.Scan(Function, nil)
+
+    if Config.Garbage and Initial.Garbage > Config.Delta then
+        TAC.Flag("JIT Hooks", "Just-In-Time Garbage Size [delta: %i]", Initial.Garbage)
+        return true
+    elseif Config.Lines then
+        local Secondary = TAC.JITHooks.Scan(Function, nil)
+        
+        if Initial.Lines ~= Secondary.Lines then
+            TAC.Flag("JIT Hooks", "Just-In-Time Lines [first: %i; second: %i]", Initial.Lines, Secondary.Lines)
+            return true
+        end
+    end
+
+    return false
+end
+
+function TAC.JITHooks.Step(Index)
+    Index = Index or 1
+
+    local Function = List[Index]
+
+    if not Function then
+        return
+    end
+
+    local Break = TAC.JITHooks.Run(Function)
+
+    if Break then
+        return
+    end
+
+    timer.Simple(Config.Step, function()
+        TAC.JITHooks.Step(Index + 1)
+    end)
+end
+
+timer.Simple(Config.Step, TAC.JITHooks.Step)

--- a/lua/tac/modules/integrity/cl_libraries.lua
+++ b/lua/tac/modules/integrity/cl_libraries.lua
@@ -1,0 +1,29 @@
+TAC.Libraries = { }
+
+function TAC.Libraries.Run()
+	local Config = TAC.Config.Libraries
+	
+	if not Config.Enabled then
+		return
+	end
+
+	-- Command list.
+	if Config.Command then		
+		local Size = TAC.Sizes.Commands.Size or "nothing"
+		
+		if Size ~= Config.Commands then
+			return TAC.Flag("Libraries", "Bad Libraries [concommand; expected: %i; got: %s]", Config.Commands, Size)
+		end
+	end
+	
+	-- Net list.
+	if Config.Net then		
+		local Size = TAC.Sizes.Net.Size or "nothing"
+		
+		if Size ~= Config.Nets then
+			return TAC.Flag("Libraries", "Bad Libraries [net; expected: %i; got: %s]", Config.Nets, Size)
+		end
+	end
+end
+
+TAC.Libraries.Run()

--- a/lua/tac/modules/integrity/init.lua
+++ b/lua/tac/modules/integrity/init.lua
@@ -2,6 +2,7 @@ if SERVER then
 	return {
 		"cl_error_tracer.lua",
 		"cl_stack.lua",
+		"cl_libraries.lua",
 		"cl_debug_self.lua",
 		"cl_debug_hooks.lua"
 	}

--- a/lua/tac/modules/movement/sv_input.lua
+++ b/lua/tac/modules/movement/sv_input.lua
@@ -17,6 +17,7 @@ function TAC.Movement.Input(Player, cNew, cOld, CUserCMD)
 	elseif Side > Config.Minimum and not Config.Vectors[Side] then
 		TAC.Punishment.Wrapper("Input", Player, "Input [side: %i]", math.Round(Side, 2))
 	end
+	
 end
 
 hook.Add("TAC.StartCommandPlus", "TAC.Movement.Input", TAC.Movement.Input)


### PR DESCRIPTION
Reverts ryanoutcome20/Trinity-Anti-Cheat#57; meant to be merged into `dev` not `main`, oops.