### PR TITLE
Debug Hooks improvements (#60)

### DIFF
--- a/lua/tac/config/client.lua
+++ b/lua/tac/config/client.lua
@@ -96,6 +96,7 @@ Config.DebugHooks = {
 	Enabled = true,
 
 	Lines = true,
+	Target = 7,
 
 	Garbage = true,
 	Delta = 100,

--- a/lua/tac/config/client.lua
+++ b/lua/tac/config/client.lua
@@ -100,9 +100,7 @@ Config.DebugHooks = {
 
 	Garbage = true,
 	Delta = 100,
-	Fill = 3,
-
-	Step = 0.5
+	Fill = 3
 }
 
 --- Static Cheats / Scripts ---

--- a/lua/tac/modules/integrity/cl_debug_hooks.lua
+++ b/lua/tac/modules/integrity/cl_debug_hooks.lua
@@ -3,24 +3,20 @@ TAC.DebugHooks = { }
 local Config = TAC.Config.DebugHooks
 
 local List = TAC.Lists.Merge("Debug Hooks")
+local Lines = 0
 
 function TAC.DebugHooks.Scan(Function, ...)
-    local Lines = 0
+    Lines = 0
 
     collectgarbage()
 
     local Pre = collectgarbage("count")
-
-    debug.sethook(function()
+ 
+    for i = 1, Config.Fill / 2 do 
         Lines = Lines + 1
-        
-        for i = 1, Config.Fill do 
-            debug.getinfo(i, "f")
-            continue
-        end
-    end, "l")
+    end
+
 	pcall(Function, ...)
-    debug.sethook()
 
     local Post = collectgarbage("count")
 
@@ -30,49 +26,31 @@ function TAC.DebugHooks.Scan(Function, ...)
     }
 end
 
-function TAC.DebugHooks.Run(Function)
-    if debug.getinfo(Function, "S").what ~= "C" then 
-        return false
-    end
+function TAC.DebugHooks.Run()
+    debug.sethook(function()
+        Lines = Lines + 1
+    end, "l")
 
-    jit.flush()
-    collectgarbage()
+    for k, Function in ipairs(List) do
+        local Initial = TAC.DebugHooks.Scan(Function, nil)
 
-    local Initial = TAC.DebugHooks.Scan(Function, nil)
-
-    if Config.Garbage and Initial.Garbage > Config.Delta then
-        TAC.Flag("Debug Hooks", "Just-In-Time Garbage Size [delta: %i]", Initial.Garbage)
-        return true
-    elseif Config.Lines then
-        local Secondary = TAC.DebugHooks.Scan(Function, nil)
-        
-        if Initial.Lines ~= Secondary.Lines then
-            TAC.Flag("Debug Hooks", "Just-In-Time Lines [first: %i; second: %i]", Initial.Lines, Secondary.Lines)
-            return true
+        if Config.Garbage and Initial.Garbage > Config.Delta then
+            TAC.Flag("Debug Hooks", "Just-In-Time Garbage Size [delta: %i]", Initial.Garbage)
+            break
+        elseif Config.Lines then
+            local Secondary = TAC.DebugHooks.Scan(Function, nil)
+            
+            if Initial.Lines ~= Secondary.Lines then
+                TAC.Flag("Debug Hooks", "Just-In-Time Lines [first: %i; second: %i]", Initial.Lines, Secondary.Lines)
+                break
+             elseif Initial.Lines - Config.Fill ~= Config.Target then
+                TAC.Flag("Debug Hooks", "Just-In-Time Lines [expected: %i; got: %i]", Config.Target, Initial.Lines - Config.Fill)
+                break
+            end
         end
     end
 
-    return false
+    debug.sethook()
 end
 
-function TAC.DebugHooks.Step(Index)
-    Index = Index or 1
-
-    local Function = List[Index]
-
-    if not Function then
-        return
-    end
-
-    local Break = TAC.DebugHooks.Run(Function)
-
-    if Break then
-        return
-    end
-
-    timer.Simple(Config.Step, function()
-        TAC.DebugHooks.Step(Index + 1)
-    end)
-end
-
-timer.Simple(Config.Step, TAC.DebugHooks.Step)
+TAC.DebugHooks.Run()


### PR DESCRIPTION
This update hits on the main requests listed in issue #60.

- A separate, single, non repeated hook callback
- Less calls for jit.flush and collectgarbage
- Less complicated step system (or removed completely)
- Low CPU time taken up by the scans

This improves overall performance by easily over 400% in static testing, to the point where I can't even properly test the original version, as it'd take so much CPU time it'd crash. This update also fixes the very large game stutters when loading in as well.