### PR TITLE
Angles Spawn Issue (#70)

### DIFF
--- a/lua/tac/config/server.lua
+++ b/lua/tac/config/server.lua
@@ -268,6 +268,8 @@ pStub.Register("Angles", {
 	MaxPitch = 90,
 	CheckYaw = true,
 	MaxYaw = 180,
+
+	TimeSinceCreated = 5,
 	
 	Vehicles = true
 })

--- a/lua/tac/modules/aimbot/sv_angles.lua
+++ b/lua/tac/modules/aimbot/sv_angles.lua
@@ -5,6 +5,10 @@ function TAC.Aimbot.Angles(Player, cNew, cOld, CUserCMD)
 		return
 	end
 
+	if TAC.TimeSinceCreated(Player) <= Config.TimeSinceCreated then
+		return
+	end
+
 	local Angles = cNew:GetViewAngles()
 
 	if Config.CheckPitch and math.abs(Angles.x) > (Config.MaxPitch + 1) then


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/ryanoutcome20/Trinity-Anti-Cheat/issues/70 by adding a customizable spawn delay to the flagging of angles. Note that the engine fixes itself after about ten ticks so you don't actually have to worry about AFK players.

Closes #70 